### PR TITLE
Converting API from Notifier to Filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
 all:
 	ponyc -d .
+	./pony-raw1

--- a/main.pony
+++ b/main.pony
@@ -11,13 +11,16 @@ actor Main
       RawFilter
       .>set_listening((recover tag this end)~listening())
       .>set_not_listening((recover tag this end)~not_listening())
-//      .>set_raw_ipv4((recover tag this end)~print_ipv4())
       .>set_raw_ipv4_icmp((recover tag this end)~print_icmp4())
+      .>set_raw_ipv4_tcp((recover tag this end)~print_tcp4())
+
+      // If it's not tcp or icmp, hit the raw callback
+      .>set_raw_ipv4((recover tag this end)~print_ipv4())
     end
-    let socket: RawSocket = RawSocket(NetAuth(env.root), consume filter) // , recover MyRawSocketNotify end)
+    let socket: RawSocket = RawSocket(NetAuth(env.root), consume filter)
 
   be listening() => env.err.print("Listening…")
-  be not_listening() => env.err.print("Not listening…")
+  be not_listening() => env.err.print("Not listening… We probably need root to open a raw socket")
 
   be print_ipv4(ipv4: IPv4Packet iso) => Debug.out("Raw IPv4: " +
                                     ipv4.srcString() +
@@ -29,27 +32,10 @@ actor Main
                                     " → " +
                                     icmp.ip4packet.dstString())
 
+  be print_tcp4(tcp4: RawTCP4 iso) => Debug.out("Raw TCP4: " +
+                                    tcp4.ip4packet.srcString() + ":" +
+                                    tcp4.srcport.string() +
+                                    " → " +
+                                    tcp4.ip4packet.dstString() + ":" +
+                                    tcp4.dstport.string())
 
-/*
-class MyRawSocketNotify is RawSocketNotifier
-  fun listening(listen: RawSocket) =>
-    Debug.out("I'm listening…")
-  fun not_listening(listen: RawSocket) =>
-    Debug.out("I'm NOT listening…")
-  fun closed(listen: RawSocket) =>
-    Debug.out("Closed…")
-  fun got_ipv4(listen: RawSocket, ipv4: IPv4Packet) =>
-    match ipv4.protocol
-    | let x: None => None
-    | let x: RawICMP4 => Debug.out("ICMP: " +
-                                   ipv4.srcString() +
-                                   " → " +
-                                   ipv4.dstString())
-    | let x: RawTCP4 => Debug.out("TCP:  " + ipv4.srcString() +
-                                  ":" + x.srcport.string() +
-                                  " → " +
-                                  ipv4.dstString() +
-                                  ":" + x.dstport.string())
-    end
-//    Debug.out(ipv4.srcString() + " → " + ipv4.dstString())
-//    */

--- a/pony-raw/ipv4_packet.pony
+++ b/pony-raw/ipv4_packet.pony
@@ -2,7 +2,7 @@ class IPv4Packet
   var srcip: IPv4Addr = 0
   var dstip: IPv4Addr = 0
   let ip4packet: Array[U8] val
-  var protocol: (RawICMP4 | RawTCP4 | None) = None
+//  var protocol: (RawICMP4 | RawTCP4 | None) = None
 
   new create(incpkt: Array[U8] val)? =>
     ip4packet = incpkt
@@ -16,6 +16,7 @@ class IPv4Packet
       dstip = ip4packet.read_u32(16)?.bswap()   // operations.
     end
 
+    /*
     protocol =
     match ip4packet(9)?
     | let p: U8 if (p == 1) => RawICMP4(this, (20 + ((vihl - 5) * 4)).usize())?
@@ -28,6 +29,7 @@ class IPv4Packet
     else
       error
     end
+    */
 
 
   fun ip2string(ipval: IPv4Addr): String =>

--- a/pony-raw/ipv4_packet.pony
+++ b/pony-raw/ipv4_packet.pony
@@ -2,7 +2,6 @@ class IPv4Packet
   var srcip: IPv4Addr = 0
   var dstip: IPv4Addr = 0
   let ip4packet: Array[U8] val
-//  var protocol: (RawICMP4 | RawTCP4 | None) = None
 
   new create(incpkt: Array[U8] val)? =>
     ip4packet = incpkt
@@ -15,22 +14,6 @@ class IPv4Packet
       srcip = ip4packet.read_u32(12)?.bswap()   // We want bigendian so we can do network
       dstip = ip4packet.read_u32(16)?.bswap()   // operations.
     end
-
-    /*
-    protocol =
-    match ip4packet(9)?
-    | let p: U8 if (p == 1) => RawICMP4(this, (20 + ((vihl - 5) * 4)).usize())?
-    | let p: U8 if (p == 2) => None  // IGMP
-    | let p: U8 if (p == 6) => RawTCP4(this, (20 + ((vihl - 5) * 4)).usize())?  // TCP
-    | let p: U8 if (p == 17) => None // UDP
-    | let p: U8 if (p == 41) => None // ENCAP
-    | let p: U8 if (p == 89) => None // OSPF
-    | let p: U8 if (p == 132) => None // SCTP
-    else
-      error
-    end
-    */
-
 
   fun ip2string(ipval: IPv4Addr): String =>
     ipval.op_and(0b11111111_00000000_00000000_00000000).shr(24).string() + "." +

--- a/pony-raw/raw_filter.pony
+++ b/pony-raw/raw_filter.pony
@@ -1,0 +1,12 @@
+class RawFilter
+  var listening: ({(): None} val | None) = None
+  var not_listening: ({(): None} val | None) = None
+  var raw_ipv4: ({(IPv4Packet iso): None} val | None) = None
+  var raw_ipv4_icmp: ({(RawICMP4 iso): None} val | None) = None
+//  var raw_ipv4_tcp:  {(RawTCP4): None}  val = {(_: RawTCP4)  => None}
+
+  fun ref set_listening(cb: {(): None} val) => listening = cb
+  fun ref set_not_listening(cb: {(): None} val) => not_listening = cb
+  fun ref set_raw_ipv4(cb: {(IPv4Packet iso): None} val) => raw_ipv4 = cb
+  fun ref set_raw_ipv4_icmp(cb: {(RawICMP4 iso): None} val) => raw_ipv4_icmp = cb
+//  fun ref set_raw_ipv4_tcp(cb: {(RawTCP4): None} val) => raw_ipv4_tcp = cb

--- a/pony-raw/raw_filter.pony
+++ b/pony-raw/raw_filter.pony
@@ -1,12 +1,12 @@
 class RawFilter
-  var listening: ({(): None} val | None) = None
-  var not_listening: ({(): None} val | None) = None
-  var raw_ipv4: ({(IPv4Packet iso): None} val | None) = None
-  var raw_ipv4_icmp: ({(RawICMP4 iso): None} val | None) = None
-//  var raw_ipv4_tcp:  {(RawTCP4): None}  val = {(_: RawTCP4)  => None}
+  var listening:     ({(): None} val               | None) = None
+  var not_listening: ({(): None} val               | None) = None
+  var raw_ipv4:      ({(IPv4Packet iso): None} val | None) = None
+  var raw_ipv4_icmp: ({(RawICMP4 iso): None} val   | None) = None
+  var raw_ipv4_tcp:  ({(RawTCP4 iso): None} val    | None) = None
 
-  fun ref set_listening(cb: {(): None} val) => listening = cb
-  fun ref set_not_listening(cb: {(): None} val) => not_listening = cb
-  fun ref set_raw_ipv4(cb: {(IPv4Packet iso): None} val) => raw_ipv4 = cb
-  fun ref set_raw_ipv4_icmp(cb: {(RawICMP4 iso): None} val) => raw_ipv4_icmp = cb
-//  fun ref set_raw_ipv4_tcp(cb: {(RawTCP4): None} val) => raw_ipv4_tcp = cb
+  fun ref set_listening(    cb: {(): None}   val) => listening = cb
+  fun ref set_not_listening(cb: {(): None}   val) => not_listening = cb
+  fun ref set_raw_ipv4(     cb: {(IPv4Packet iso): None} val) => raw_ipv4 = cb
+  fun ref set_raw_ipv4_icmp(cb: {(RawICMP4   iso): None} val) => raw_ipv4_icmp = cb
+  fun ref set_raw_ipv4_tcp( cb: {(RawTCP4    iso): None} val) => raw_ipv4_tcp = cb

--- a/pony-raw/raw_icmpv4.pony
+++ b/pony-raw/raw_icmpv4.pony
@@ -1,10 +1,10 @@
 class RawICMP4
-  let ip4packet: IPv4Packet
+  let ip4packet: IPv4Packet val
   let offset: USize
   let icmptype: U8
   let icmpcode: U8
 
-  new create(ip4packet': IPv4Packet, offset': USize)? =>
+  new create(ip4packet': IPv4Packet val, offset': USize)? =>
     ip4packet = ip4packet'
     offset = offset'
 

--- a/pony-raw/raw_socket_notifier.pony
+++ b/pony-raw/raw_socket_notifier.pony
@@ -1,5 +1,0 @@
-interface RawSocketNotifier
-  fun listening(listen: RawSocket) => None
-  fun not_listening(listen: RawSocket) => None
-  fun closed(listen: RawSocket) => None
-  fun got_ipv4(listen: RawSocket, ipv4: IPv4Packet iso) => None

--- a/pony-raw/raw_tcp4.pony
+++ b/pony-raw/raw_tcp4.pony
@@ -1,7 +1,7 @@
 use @printf[I32](fmt: Pointer[U8] tag, ...)
 
 class RawTCP4
-  let ip4packet: IPv4Packet
+  let ip4packet: IPv4Packet val
   let offset: USize
 
   let srcport: U16
@@ -11,7 +11,7 @@ class RawTCP4
   let dataoff: U8
   let flags: U8
 
-  new create(ip4packet': IPv4Packet, offset': USize)? =>
+  new create(ip4packet': IPv4Packet val, offset': USize)? =>
     ip4packet = ip4packet'
     offset = offset'
 


### PR DESCRIPTION
The purpose of this API change is to provide the opportunity for unsupported / unwanted packets to be dropped ASAP and without any message passing.